### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/20240429_AI_Agents_Autogen_LMStudio/README.md
+++ b/20240429_AI_Agents_Autogen_LMStudio/README.md
@@ -38,7 +38,7 @@ This project demonstrates:
 - Python 3.8+
 - Required packages:
   ```bash
-  pip install pyautogen
+  pip install ag2
   pip install yfinance
   pip install pandas numpy
   pip install matplotlib seaborn

--- a/20240501 autogen command line executors/README.md
+++ b/20240501 autogen command line executors/README.md
@@ -42,7 +42,7 @@ The project illustrates:
 - Python 3.8+
 - Required packages:
   ```bash
-  pip install pyautogen
+  pip install ag2
   ```
 
 ### Core Components
@@ -84,7 +84,7 @@ code_executor_agent = ConversableAgent(
 1. Clone the repository
 2. Install required dependencies:
    ```bash
-   pip install pyautogen
+   pip install ag2
    ```
 3. Open the Jupyter notebook
 4. Follow the examples and run the demonstrations

--- a/20240501_autogen_code_executors/README.md
+++ b/20240501_autogen_code_executors/README.md
@@ -32,7 +32,7 @@ This project demonstrates:
 - Python 3.8+
 - Required packages:
   ```bash
-  pip install pyautogen
+  pip install ag2
   pip install pandas numpy
   pip install matplotlib seaborn
   pip install jupyter

--- a/20240906_autogen_nested_chat/README.md
+++ b/20240906_autogen_nested_chat/README.md
@@ -43,7 +43,7 @@ This project showcases:
 - Python 3.8+
 - Required packages:
   ```bash
-  pip install pyautogen openai
+  pip install ag2 openai
   ```
 - OpenAI API key or compatible LLM setup
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
